### PR TITLE
Rework scripts

### DIFF
--- a/droplet/README.md
+++ b/droplet/README.md
@@ -64,7 +64,7 @@ docker compose exec proxy ls -la /etc/letsencrypt/live
 Generate your key with the openssl command:
 
 ```console
-sudo openssl dhparam -out /home/torrust/github/josecelano/torrust-compose/droplet/storage/dhparam/dhparam-2048.pem 2048
+sudo openssl dhparam -out /home/torrust/github/torrust/torrust-compose/droplet/storage/dhparam/dhparam-2048.pem 2048
 ```
 
 Edit the Nginx config file:
@@ -205,13 +205,13 @@ storage
 To start the application:
 
 ```s
-./bin/start.sh
+docker compose up --build --detach
 ```
 
 To stop the application:
 
 ```s
-./bin/stop.sh
+docker compose down
 ```
 
 By default, the application will:
@@ -229,4 +229,26 @@ fbed1b994c7a   nginx:mainline-alpine       "/docker-entrypoint.…"   4 minutes 
 5d8e6fb74102   torrust/index-gui:develop   "/usr/local/bin/entr…"   4 minutes ago   Up 4 minutes (healthy)   0.0.0.0:3000->3000/tcp, :::3000->3000/tcp                                                                                                   index-gui
 60854e389bb7   torrust/index:develop       "/usr/local/bin/entr…"   4 minutes ago   Up 4 minutes (healthy)   0.0.0.0:3001->3001/tcp, :::3001->3001/tcp                                                                                                   index
 16b1a40d96f9   torrust/tracker:develop     "/usr/local/bin/entr…"   4 minutes ago   Up 4 minutes (healthy)   0.0.0.0:1212->1212/tcp, :::1212->1212/tcp, 0.0.0.0:7070->7070/tcp, :::7070->7070/tcp, 1313/tcp, 0.0.0.0:6969->6969/udp, :::6969->6969/udp   tracker
+```
+
+Other commands are:
+
+Restart all (reloading env vars from `.env` file by forcing recreation):
+
+```console
+docker compose up -d --force-recreate
+```
+
+Restart proxy (to reload Nginx configuration):
+
+```console
+docker compose --ansi never restart proxy
+```
+
+Update container images (to upgrade the services):
+
+```console
+docker compose down
+docker compose pull
+docker compose up --build --detach
 ```

--- a/droplet/bin/restart.sh
+++ b/droplet/bin/restart.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-TORRUST_INDEX_CONFIG_PATH=$(cat ./storage/index/etc/index.toml) \
-TORRUST_TRACKER_CONFIG_PATH=$(cat ./storage/tracker/etc/tracker.toml) \
-TORRUST_TRACKER_API_ADMIN_TOKEN=${TORRUST_TRACKER_API_ADMIN_TOKEN:-MyAccessToken} \
-TORRUST_INDEX_TRACKER_API_TOKEN=${TORRUST_INDEX_TRACKER_API_TOKEN:-MyAccessToken} \
-	docker compose restart

--- a/droplet/bin/restart_proxy.sh
+++ b/droplet/bin/restart_proxy.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-TORRUST_INDEX_CONFIG_PATH=$(cat ./storage/index/etc/index.toml) \
-TORRUST_TRACKER_CONFIG_PATH=$(cat ./storage/tracker/etc/tracker.toml) \
-TORRUST_TRACKER_API_ADMIN_TOKEN=${TORRUST_TRACKER_API_ADMIN_TOKEN:-MyAccessToken} \
-TORRUST_INDEX_TRACKER_API_TOKEN=${TORRUST_INDEX_TRACKER_API_TOKEN:-MyAccessToken} \
-	docker compose --ansi never restart proxy

--- a/droplet/bin/ssl_renew.sh
+++ b/droplet/bin/ssl_renew.sh
@@ -10,6 +10,6 @@ cd /home/torrust/github/torrust/torrust-compose/droplet || exit
 
 # Renew certificates that are close to expiring and restart proxy server
 # to reload Nginx congiuration.
-$COMPOSE run certbot renew && ./bin/restart_proxy.sh
+$COMPOSE run certbot renew && $COMPOSE --ansi never restart proxy
 
 $DOCKER system prune -af

--- a/droplet/bin/start.sh
+++ b/droplet/bin/start.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-TORRUST_INDEX_CONFIG_PATH=$(cat ./storage/index/etc/index.toml) \
-TORRUST_TRACKER_CONFIG_PATH=$(cat ./storage/tracker/etc/tracker.toml) \
-TORRUST_TRACKER_API_ADMIN_TOKEN=${TORRUST_TRACKER_API_ADMIN_TOKEN:-MyAccessToken} \
-TORRUST_INDEX_TRACKER_API_TOKEN=${TORRUST_INDEX_TRACKER_API_TOKEN:-MyAccessToken} \
-	docker compose up --build --detach

--- a/droplet/bin/stop.sh
+++ b/droplet/bin/stop.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker compose down

--- a/droplet/bin/update.sh
+++ b/droplet/bin/update.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-./bin/stop.sh
-docker compose pull
-./bin/start.sh


### PR DESCRIPTION
- Make them simpler.
- Take env vars directly from `.env` file, that means you have to execute "docker compose" in the root dir directly.