### PR TITLE
Fix problem with proxy config for image proxy

### DIFF
--- a/droplet/share/container/default/config/nginx.conf
+++ b/droplet/share/container/default/config/nginx.conf
@@ -8,9 +8,19 @@ server
 
 	server_name index.torrust-demo.com;
 
-	location ^~/api/
+	error_log /var/log/nginx/error.log debug;
+
+	location /api/v1/proxy
 	{
-		proxy_pass http://index:3001/;
+		rewrite ^ $request_uri;
+		rewrite ^/api(/.*) $1 break;
+		proxy_pass http://index:3001;
+	}
+
+	location ^~ /api/
+	{
+		rewrite ^/api/(.*)$ /$1 break;
+		proxy_pass http://index:3001;
 	}
 
 	location /
@@ -35,9 +45,11 @@ server
 
 	server_name tracker.torrust-demo.com;
 
+	error_log /var/log/nginx/error.log debug;
+
 	location /api/
 	{
-		proxy_pass http://tracker:1212/api/;
+		proxy_pass http://tracker:1212;
 	}
 
 	location /
@@ -58,6 +70,8 @@ server
 #	listen [::]:443 ssl http2;
 #	server_name index.torrust-demo.com;
 #
+#	error_log /var/log/nginx/error.log debug;
+#	merge_slashes off;
 #	server_tokens off;
 #
 #	ssl_certificate /etc/letsencrypt/live/index.torrust-demo.com-0001/fullchain.pem;
@@ -79,9 +93,19 @@ server
 #	ssl_stapling_verify on;
 #	resolver 8.8.8.8;
 #
+#	error_log /var/log/nginx/error.log debug;
+#
+#	location /api/v1/proxy
+#	{
+#		rewrite ^ $request_uri;
+#		rewrite ^/api(/.*) $1 break;
+#		#proxy_pass http://index:3001;
+#		try_files $uri @index;
+#	}
+#
 #	location ^~/api/
 #	{
-#        rewrite ^/api/(.*)$ /$1 break;
+#		rewrite ^/api/(.*)$ /$1 break;
 #		try_files $uri @index;
 #	}
 #


### PR DESCRIPTION
We need to pass the original URL encoded URL:

http://index.torrust-demo.com/api/v1/proxy/image/https%3A%2F%2Fraw.githubusercontent.com%2Ftorrust%2Ftorrust-index%2Fdevelop%2Fdocs%2Fmedia%2Ftorrust_logo.png

from the Nginx reverse proxy to the Index API image proxy.

Otherwise we get a 404. The proxy was passing an URL like this:

"/v1/proxy/image/https:/raw.githubusercontent.com/torrust/torrust-index/develop/docs/media/torrust_logo.png

which is not valid because it containts unscaped chars.

Not It's passing:

"/v1/proxy/image/https%3A%2F%2Fraw.githubusercontent.com%2Ftorrust%2Ftorrust-index%2Fdevelop%2Fdocs%2Fmedia%2Ftorrust_logo.png"

This solution is not passing the rest of the URL: query parameters. But we do not need them in the image proxy.